### PR TITLE
Added endpoint to update the confirmation code when the run fails bec…

### DIFF
--- a/node_project/app.js
+++ b/node_project/app.js
@@ -133,4 +133,24 @@ app.get('/scrape', (request, response) => {
     })
 })
 
+app.get('/updateCode', (request, response) => {
+    const query = request.query
+    if (query.confirmationCode){
+        scraper.updateCode(query.confirmationCode)
+            .then(doRun => {
+                if (doRun){
+                    logger.info('Confirmation code updated, scrape process started.')
+                    response.send('Confirmation code updated, scrape process started.')
+                    runScraper().then()
+                } else {
+                    logger.info('Confirmation code updated, but scrape process not started.')
+                    response.send('Confirmation code updated, but scrape process not started.')
+                }
+            })
+    } else {
+        logger.info('No confirmation code, request ignored.')
+        response.send('No confirmation code, request ignored.')
+    }
+})
+
 initialize().then()


### PR DESCRIPTION
…ause the confirmation code is stale.  Since I don't know what login attempt caused the confirmation code to be sent to email, I need only rerun the scrape process if it failed due to a bad confirmation code.